### PR TITLE
1.11.2 backport for #9163/#6598

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 Change: [Win32] Limit hardware accelerated video driver to OpenGL 3.2 or higher (#9077)
 Change: More improvements to windows at different GUI scales (#9075, #9102, #9107, #9133)
+Fix #6598: Crash when trying to connect to a server from a network game (#9163)
 Fix #9152: Screenshot success popup window was treated as an error (#9159)
 Fix: [Network,Win32] Network errors were handled badly (#9116)
 Fix: [Network] Savegame transfer could stall in certain circumstances (#9106)

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -908,7 +908,6 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	}
 
 	if (argc < 2) return false;
-	if (_networking) NetworkDisconnect(); // we are in network-mode, first close it!
 
 	const char *port = nullptr;
 	const char *company = nullptr;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -670,13 +670,33 @@ void NetworkClientConnectGame(const char *hostname, uint16 port, CompanyID join_
 	_network_join_server_password = join_server_password;
 	_network_join_company_password = join_company_password;
 
+	if (_game_mode == GM_MENU) {
+		/* From the menu we can immediately continue with the actual join. */
+		NetworkClientJoinGame();
+	} else {
+		/* When already playing a game, first go back to the main menu. This
+		 * disconnects the user from the current game, meaning we can safely
+		 * load in the new. After all, there is little point in continueing to
+		 * play on a server if we are connecting to another one.
+		 */
+		_switch_mode = SM_JOIN_GAME;
+	}
+}
+
+/**
+ * Actually perform the joining to the server. Use #NetworkClientConnectGame
+ * when you want to connect to a specific server/company. This function
+ * assumes _network_join is already fully set up.
+ */
+void NetworkClientJoinGame()
+{
 	NetworkDisconnect();
 	NetworkInitialize();
 
 	_network_join_status = NETWORK_JOIN_STATUS_CONNECTING;
 	ShowJoinStatusWindow();
 
-	new TCPClientConnecter(NetworkAddress(hostname, port));
+	new TCPClientConnecter(NetworkAddress(_settings_client.network.last_host, _settings_client.network.last_port));
 }
 
 static void NetworkInitGameInfo()

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -49,6 +49,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
 void NetworkClientConnectGame(const char *hostname, uint16 port, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1109,6 +1109,11 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 		}
 
+		case SM_JOIN_GAME: // Join a multiplayer game
+			LoadIntroGame();
+			NetworkClientJoinGame();
+			break;
+
 		case SM_MENU: // Switch to game intro menu
 			LoadIntroGame();
 			if (BaseSounds::ini_set.empty() && BaseSounds::GetUsedSet()->fallback && SoundDriver::GetInstance()->HasOutput()) {

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -36,6 +36,7 @@ enum SwitchMode {
 	SM_START_HEIGHTMAP,   ///< Load a heightmap and start a new game from it.
 	SM_LOAD_HEIGHTMAP,    ///< Load heightmap from scenario editor.
 	SM_RESTART_HEIGHTMAP, ///< Load a heightmap and start a new game from it with current settings.
+	SM_JOIN_GAME,         ///< Join a network game.
 };
 
 /** Display Options */


### PR DESCRIPTION
I already did most of the heavy lifting for backporting #9163/#6598. I'd suggest to rebase it to be in-line with the other commits and collapse the changelog update into that commit, if you're happy to put this in 1.11.2.
